### PR TITLE
NET changed regtest RPCport to 18443 to avoid conflict with testnet 18332

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -3,8 +3,15 @@ rpcuser=someuser
 rpcpassword=somepassword
 #datadir=~/.bitcoin
 host=127.0.0.1
+
+#mainnet default
 port=8332
+
+#testnet default
 #port=18332
+
+#regtest default
+#port=18443
 
 # bootstrap.dat hashlist settings (linearize-hashes)
 max_height=313000

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -336,6 +336,8 @@ done
 %{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8333
 %{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18332
 %{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18333
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18443
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18444
 %{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
 %{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin || :
 fi
@@ -355,6 +357,8 @@ if [ $1 -eq 0 ]; then
 	%{_sbindir}/semanage port -d -p tcp 8333
 	%{_sbindir}/semanage port -d -p tcp 18332
 	%{_sbindir}/semanage port -d -p tcp 18333
+	%{_sbindir}/semanage port -d -p tcp 18443
+	%{_sbindir}/semanage port -d -p tcp 18444
 	for selinuxvariant in %{selinux_variants}; do
 		%{_sbindir}/semodule -s ${selinuxvariant} -r bitcoin &> /dev/null || :
 	done

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -3,7 +3,8 @@ Unauthenticated REST Interface
 
 The REST API can be enabled with the `-rest` option.
 
-The interface runs on the same port as the JSON-RPC interface, by default port 8332 for mainnet and port 18332 for testnet.
+The interface runs on the same port as the JSON-RPC interface, by default port 8332 for mainnet, port 18332 for testnet,
+and port 18443 for regtest.
 
 Supported API
 -------------

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -57,7 +57,7 @@ class CBaseRegTestParams : public CBaseChainParams
 public:
     CBaseRegTestParams()
     {
-        nRPCPort = 18332;
+        nRPCPort = 18443;
         strDataDir = "regtest";
     }
 };


### PR DESCRIPTION
using same RPCport for both testnet and regtest prevent running both at the same time on the same machine. Since RPCport=P2Pport-1 for both mainnet and testnet, and regtest P2Pport is 18444, 18443 is proposed for regtest RPCport